### PR TITLE
Use protocol-relative Gravatar URL

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>avatar</artifactId>
         <groupId>ru.mail.teamcity</groupId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
     <artifactId>build</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ru.mail.teamcity</groupId>
   <artifactId>avatar</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
   <packaging>pom</packaging>
   <properties>
       <teamcity-version>9.0</teamcity-version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>avatar</artifactId>
         <groupId>ru.mail.teamcity</groupId>
-        <version>1.2</version>
+        <version>1.3</version>
     </parent>
     <artifactId>avatar-server</artifactId>
     <packaging>jar</packaging>

--- a/server/src/main/java/ru/mail/teamcity/avatar/supplier/impl/GravatarAvatarSupplier.java
+++ b/server/src/main/java/ru/mail/teamcity/avatar/supplier/impl/GravatarAvatarSupplier.java
@@ -3,7 +3,6 @@ package ru.mail.teamcity.avatar.supplier.impl;
 import com.timgroup.jgravatar.Gravatar;
 import com.timgroup.jgravatar.GravatarDefaultImage;
 import com.timgroup.jgravatar.GravatarRating;
-import jetbrains.buildServer.serverSide.impl.ServerSettings;
 import jetbrains.buildServer.users.SUser;
 import org.jetbrains.annotations.NotNull;
 import ru.mail.teamcity.avatar.supplier.AbstractAvatarSupplier;
@@ -21,11 +20,7 @@ public class GravatarAvatarSupplier extends AbstractAvatarSupplier implements In
     @NotNull
     private final Gravatar gravatar;
 
-    @NotNull
-    private final ServerSettings serverSettings;
-
-    public GravatarAvatarSupplier(@NotNull ServerSettings serverSettings) {
-        this.serverSettings = serverSettings;
+    public GravatarAvatarSupplier() {
         gravatar = new Gravatar();
         gravatar.setRating(GravatarRating.GENERAL_AUDIENCES);
         gravatar.setDefaultImage(GravatarDefaultImage.IDENTICON);
@@ -36,10 +31,7 @@ public class GravatarAvatarSupplier extends AbstractAvatarSupplier implements In
         String mail = user.getEmail();
         if (null != mail) {
             String url = gravatar.getUrl(mail);
-            String rootUrl = serverSettings.getRootUrl();
-            if (rootUrl != null && rootUrl.startsWith("https://")) {
-                url = url.replace("http://", "https://");
-            }
+            url = url.replace("http://", "//");
             return url;
         }
         return "";


### PR DESCRIPTION
* make use of protocol-relative URLs as suggested in https://github.com/grundic/teamcity-avatar/issues/3#issuecomment-120484679
* by using protocol-relative URLs we no longer need to inspect ServerSettings for the configured root URL, so we can remove that dependency and also fix [the exception that caused the plugin to be unavailable](https://github.com/grundic/teamcity-avatar/issues/3#issuecomment-120595970)